### PR TITLE
Allow usage of floats

### DIFF
--- a/render_knob_scale.inx
+++ b/render_knob_scale.inx
@@ -5,11 +5,11 @@
     <dependency type="executable" location="inx">render_knob_scale.py</dependency>
     <param name="tab" type="notebook">
         <page name="general_settings" gui-text="General">
-            <param name="x" type="int"   min="-1000" max="10000" gui-text="Center X:">0</param>
-            <param name="y" type="int"   min="-1000" max="10000" gui-text="Center Y:">0</param>
-            <param name="radius" type="int"   min="10" max="10000" gui-text="Knob size:">100</param>
-            <param name="angle" type="float"   min="90.0" max="360.0" gui-text="Angle">300</param>
-            <param name="linewidth" type="int"   min="1" max="100" gui-text="Line width">1</param>
+            <param name="x" type="float"   min="-1000" max="10000" precision="3" gui-text="Center X:">0</param>
+            <param name="y" type="float"   min="-1000" max="10000" precision="3" gui-text="Center Y:">0</param>
+            <param name="radius" type="float"   min="0.001" max="10000" precision="3" gui-text="Knob radius:">100</param>
+            <param name="angle" type="float"   min="90.0" max="360.0" precision="3" gui-text="Angle">300</param>
+            <param name="linewidth" type="float"   min="0.001" max="100" precision="3" gui-text="Line width">1</param>
             <param name="draw_arc" type="bool" gui-text="Draw Arc">true</param>
             <param name="draw_centering_circle" type="bool" gui-text="Draw Centering Circle">false</param>
             <param name="units" type="optiongroup" gui-text="Units" appearance="combo">
@@ -20,9 +20,9 @@
 
         <page name="ticks_settings" gui-text="Marks">
             <param name="n_ticks" type="int"   min="2" max="100" gui-text="Number of tick marks:">2</param>
-            <param name="ticksize" type="int"   min="1" max="1000" gui-text="Tick size: ">10</param>
+            <param name="ticksize" type="float"   min="0.001" max="1000" precision="3" gui-text="Tick size: ">10</param>
             <param name="n_subticks" type="int"   min="0" max="100" gui-text="Number of subticks:">1</param>
-            <param name="subticksize" type="int"   min="1" max="1000" gui-text="Subtick size: ">5</param>
+            <param name="subticksize" type="float"   min="0.001" max="1000" precision="3" gui-text="Subtick size: ">5</param>
             <param name="style" type="optiongroup" gui-text="Scale style" appearance="combo">
                 <item value="marks_inwards">Marks inwards</item>
                 <item value="marks_outwards">Marks outwards</item>
@@ -32,10 +32,10 @@
         <page name="labels_settings" gui-text="Labels">
             <param name="labels_enabled" type="bool" gui-text="Enable labels">false</param>
             <param name="rounding_level" type="int" min="0" max="100" gui-text="Rounding Float to">0</param>
-            <param name="text_size" type="int" min="1" max="100" gui-text="Labels size">10</param>
-            <param name="text_offset" type="int" min="-1000" max="1000" gui-text="Offset">20</param>
-            <param name="start_value" type="float"   min="-10000" max="10000" gui-text="Start Value">0</param>
-            <param name="stop_value" type="float"   min="-10000" max="10000" gui-text="Stop Value">10</param>
+            <param name="text_size" type="float" min="0.001" max="1000" precision="3" gui-text="Labels size">10</param>
+            <param name="text_offset" type="float" min="-1000" max="1000" precision="3" gui-text="Offset">20</param>
+            <param name="start_value" type="float"   min="-10000" max="10000" precision="3" gui-text="Start Value">0</param>
+            <param name="stop_value" type="float"   min="-10000" max="10000" precision="3" gui-text="Stop Value">10</param>
         </page>
     </param>
 

--- a/render_knob_scale.py
+++ b/render_knob_scale.py
@@ -29,19 +29,19 @@ class Knob_Scale(inkex.Effect):
         inkex.Effect.__init__(self)
         # General settings
         self.arg_parser.add_argument("--x",
-                        type=int,
+                        type=float,
                         dest="x", default=0.0,
                         help="Center X")
         self.arg_parser.add_argument("--y",
-                        type=int,
+                        type=float,
                         dest="y", default=0.0,
                         help="Center Y")
         self.arg_parser.add_argument("--radius",
-                        type=int,
+                        type=float,
                         dest="radius", default=100.0,
                         help="Knob radius")
         self.arg_parser.add_argument("--linewidth",
-                        type=int,
+                        type=float,
                         dest="linewidth", default=1,
                         help="")
         self.arg_parser.add_argument("--angle",
@@ -66,7 +66,7 @@ class Knob_Scale(inkex.Effect):
                         dest="n_ticks", default=5,
                         help="")
         self.arg_parser.add_argument("--ticksize",
-                        type=int,
+                        type=float,
                         dest="ticksize", default=10,
                         help="")
         self.arg_parser.add_argument("--n_subticks",
@@ -74,7 +74,7 @@ class Knob_Scale(inkex.Effect):
                         dest="n_subticks", default=10,
                         help="")
         self.arg_parser.add_argument("--subticksize",
-                        type=int,
+                        type=float,
                         dest="subticksize", default=5,
                         help="")
         self.arg_parser.add_argument("--style",
@@ -92,11 +92,11 @@ class Knob_Scale(inkex.Effect):
                         dest="rounding_level", default=0,
                         help="")
         self.arg_parser.add_argument("--text_size",
-                        type=int,
+                        type=float,
                         dest="text_size", default=1,
                         help="")
         self.arg_parser.add_argument("--text_offset",
-                        type=int,
+                        type=float,
                         dest="text_offset", default=20,
                         help="")
         self.arg_parser.add_argument("--start_value",


### PR DESCRIPTION
Whilst using the plugin, I found myself needing to set the parameters to fractional values. This commit allows us to use floats for properties where that would be appropriate.