### PR TITLE
fix issue#17 - error with Inkscape 1.2 when adding labels

### DIFF
--- a/render_knob_scale.py
+++ b/render_knob_scale.py
@@ -123,7 +123,7 @@ class Knob_Scale(inkex.Effect):
         style = {
                 'text-align' : 'center',
                  'text-anchor': 'middle',
-                 'alignment-baseline' : 'center',
+                 'alignment-baseline' : 'central',
                  'font-size' : str(text_size),
                  'vertical-align' : 'middle'
                  }


### PR DESCRIPTION
implement the change suggested in

https://github.com/leechwort/knob-scale-generator/issues/17#issuecomment-1141498873

This is not tested against versions of Inkscape before 1.2
