### PR TITLE
Fixed XML error

### DIFF
--- a/render_knob_scale.inx
+++ b/render_knob_scale.inx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-    <name>Knob Scale</_name>
+    <name>Knob Scale</name>
     <id>com.knob_scale</id>
     <dependency type="executable" location="inx">render_knob_scale.py</dependency>
     <param name="tab" type="notebook">


### PR DESCRIPTION
Fixes this error:

render_knob_scale.inx:3: parser error : Opening and ending tag mismatch: name line 3 and _name